### PR TITLE
Add semisol and semisol-pub

### DIFF
--- a/src/lib/relays.ts
+++ b/src/lib/relays.ts
@@ -21,7 +21,9 @@ const relayList = [
   ["wss://nostr.delo.software", 'delo'],
   ["wss://relay.minds.com/nostr/v1/ws", 'minds'],
   ["wss://nostr.oxtr.dev", 'oxtr'],
-  ["wss://moonbreeze.richardbondi.net/ws", 'richardbondi']
+  ["wss://moonbreeze.richardbondi.net/ws", 'richardbondi'],
+  ["wss://nostr.semisol.dev", 'semisol'],
+  ["wss://nostr-pub.semisol.dev", 'semisol-pub']
 ];
 
 export let relays = [];


### PR DESCRIPTION
Add my own relays.
- wss://nostr.semisol.dev: a whitelisted relay (open for whitelist requests)
- wss://nostr-pub.semisol.dev: an unwhitelisted relay but with limits to reduce spam