### PR TITLE
Public relay name change

### DIFF
--- a/src/lib/relays.ts
+++ b/src/lib/relays.ts
@@ -15,7 +15,7 @@ export const relayList: RelayInterface[] = [
   { name: "wss://rsslay.fiatjaf.com", alias: 'rsslay' },
   { name: "wss://freedom-relay.herokuapp.com/ws", alias: 'freedom.relay' },
   { name: "wss://nostr-relay.freeberty.net", alias: 'freeberty' },
-  { name: "wss://nostr.bitcoiner.social", alias: 'bitcoiner.social' },
+  { name: "wss://offchain.pub", alias: 'offchain.pub' },
   { name: "wss://nostr-relay.wlvs.space", alias: 'wlvs.space' },
   { name: "wss://nostr.onsats.org", alias: 'onsats' },
   { name: "wss://nostr-relay.untethr.me", alias: 'untethr' },


### PR DESCRIPTION
nostr.bitcoiner.social -> offchain.pub

note1zpgy9f8tlwdwhhwtzy50vpl72qkunzhmy57p4f5xaf8h57pfvwpschwe74

> Before I deployed the new pay-to-relay server, I ran a public relay under a "nostr" subdomain. I've since renamed my public relay to wss://offchain.pub. Much cooler name. Better represents how nostr isn't something this domain handles on the side, it's the primary purpose. Raison d'etre.
> 
> Both offchain.pub and the "nostr" subdomain will work concurrently for awhile, pointing to the same public relay server. But I'll eventually deprecate the "nostr" subdomain and redirect requests to the new offchain.pub name.